### PR TITLE
Fix MythicMobs faction stat reload

### DIFF
--- a/MMOItems-API/src/main/java/net/Indyuce/mmoitems/comp/mythicmobs/MythicMobsCompatibility.java
+++ b/MMOItems-API/src/main/java/net/Indyuce/mmoitems/comp/mythicmobs/MythicMobsCompatibility.java
@@ -90,5 +90,6 @@ public class MythicMobsCompatibility implements Listener {
 
         // Register new faction damage stats
         MythicMobsLoadHook.registerFactionStats(false);
+        MMOItems.plugin.getStats().reload(false);
     }
 }


### PR DESCRIPTION
## Summary
- load language data for new MythicMobs faction-damage stats

## Testing
- `mvn -e -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881ebf340f88330ab107a5719f8cd18